### PR TITLE
Remove user from group function

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -41,9 +41,9 @@ class Client
 
     use AuthTrait;
     use GroupTrait;
+    use OrganizationTrait;
     use ProjectEnvironmentTrait;
     use ProjectTrait;
-    use OrganizationTrait;
 
     /**
      * Constructor for the Lagoon API client

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,6 +6,7 @@ use FreedomtechHosting\FtLagoonPhp\ClientTraits\AuthTrait;
 use FreedomtechHosting\FtLagoonPhp\ClientTraits\GroupTrait;
 use FreedomtechHosting\FtLagoonPhp\ClientTraits\ProjectEnvironmentTrait;
 use FreedomtechHosting\FtLagoonPhp\ClientTraits\ProjectTrait;
+use FreedomtechHosting\FtLagoonPhp\ClientTraits\OrganizationTrait;
 use Softonic\GraphQL\Client as GraphqlClient;
 use Softonic\GraphQL\ClientBuilder;
 
@@ -42,6 +43,7 @@ class Client
     use GroupTrait;
     use ProjectEnvironmentTrait;
     use ProjectTrait;
+    use OrganizationTrait;
 
     /**
      * Constructor for the Lagoon API client

--- a/src/ClientTraits/GroupTrait.php
+++ b/src/ClientTraits/GroupTrait.php
@@ -75,4 +75,42 @@ trait GroupTrait
         }
 
     }
+    
+    /**
+     * @throws LagoonClientInitializeRequiredToInteractException
+     */
+    public function removeUserFromGroup(string $groupName, string $userEmail): array
+    {
+        if (empty($this->lagoonToken) || empty($this->graphqlClient)) {
+            throw new LagoonClientInitializeRequiredToInteractException;
+        }
+
+        $mutation = <<<GQL
+            mutation {
+                removeUserFromGroup(input:  {
+                    group:  {
+                        name: "{$groupName}"
+                    },
+                    user:  {
+                        email: "{$userEmail}"
+                    }
+                }){
+                    id
+                    name
+                    memberCount
+                }
+            }
+        GQL;
+
+        $response = $this->graphqlClient->query($mutation);
+
+        if ($response->hasErrors()) {
+            return ['error' => $response->getErrors()];
+        } else {
+            // Returns an array with all the data returned by the GraphQL server.
+            return $response->getData();
+        }
+
+    }
+
 }

--- a/src/ClientTraits/GroupTrait.php
+++ b/src/ClientTraits/GroupTrait.php
@@ -113,7 +113,7 @@ trait GroupTrait
 
     }
 
-       /**
+    /**
      * Gets users for a group
      *
      * @param  string  $groupName  The name of the group

--- a/src/ClientTraits/GroupTrait.php
+++ b/src/ClientTraits/GroupTrait.php
@@ -75,7 +75,7 @@ trait GroupTrait
         }
 
     }
-    
+
     /**
      * @throws LagoonClientInitializeRequiredToInteractException
      */
@@ -86,7 +86,7 @@ trait GroupTrait
         }
 
         $mutation = <<<GQL
-            mutation {
+            query {
                 removeUserFromGroup(input:  {
                     group:  {
                         name: "{$groupName}"
@@ -112,5 +112,77 @@ trait GroupTrait
         }
 
     }
+
+       /**
+     * Gets users for a group
+     *
+     * @param  string  $groupName  The name of the group
+     * @return array Emails of users in group
+     *
+     * @throws LagoonClientInitializeRequiredToInteractException if client not initialized
+     */
+    public function getGroupUsers(string $groupName): array
+    {
+        if (empty($this->lagoonToken) || empty($this->graphqlClient)) {
+            throw new LagoonClientInitializeRequiredToInteractException;
+        }
+
+        $query = <<<GQL
+            query groupByName {
+                groupByName(name: "{$groupName}") {
+                    members {
+                        user {
+                            email
+                        }
+                    }
+                }
+            }
+        GQL;
+
+        $response = $this->graphqlClient->query($query);
+
+        /***
+         * Example Response
+         * {
+  "data": {
+    "groupByName": {
+      "members": [
+        {
+          "user": {
+            "email": "default-user@polydock-amber-tiger-6994a164bf781"
+          }
+        },
+        {
+          "user": {
+            "email": "hello@bryangruneberg.com"
+          }
+        },
+        {
+          "user": {
+            "email": "hello@bryangruneberg.com"
+          }
+        }
+      ]
+    }
+  }
+}
+         */
+
+        if ($response->hasErrors()) {
+            return ['error' => $response->getErrors()];
+        }
+
+        $data = $response->getData();
+
+        $emails = [];
+        foreach ($data['groupByName']['members'] ?? [] as $member) {
+            if (isset($member['user']['email'])) {
+                $emails[] = $member['user']['email'];
+            }
+        }
+
+        return $emails;
+    }
+
 
 }

--- a/src/ClientTraits/GroupTrait.php
+++ b/src/ClientTraits/GroupTrait.php
@@ -86,7 +86,7 @@ trait GroupTrait
         }
 
         $mutation = <<<GQL
-            query {
+            mutation {
                 removeUserFromGroup(input:  {
                     group:  {
                         name: "{$groupName}"

--- a/src/ClientTraits/OrganizationTrait.php
+++ b/src/ClientTraits/OrganizationTrait.php
@@ -4,7 +4,8 @@ namespace FreedomtechHosting\FtLagoonPhp\ClientTraits;
 
 use FreedomtechHosting\FtLagoonPhp\LagoonClientInitializeRequiredToInteractException;
 
-trait OrganizationTrait {
+trait OrganizationTrait 
+{
         
     /**
      * @throws LagoonClientInitializeRequiredToInteractException

--- a/src/ClientTraits/OrganizationTrait.php
+++ b/src/ClientTraits/OrganizationTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace FreedomtechHosting\FtLagoonPhp\ClientTraits;
+
+use FreedomtechHosting\FtLagoonPhp\LagoonClientInitializeRequiredToInteractException;
+
+trait OrganizationTrait {
+        
+    /**
+     * @throws LagoonClientInitializeRequiredToInteractException
+     */
+    public function removeUserFromOrganization(int $orgId, string $userEmail): array
+    {
+        if (empty($this->lagoonToken) || empty($this->graphqlClient)) {
+            throw new LagoonClientInitializeRequiredToInteractException;
+        }
+
+        $mutation = <<<GQL
+            mutation {
+                removeUserFromOrganizationGroups(input:  {
+                    organization: {$orgId},
+                    user:  {
+                        email: "{$userEmail}"
+                    }
+                }){
+                    id
+                    name
+                }
+            }
+        GQL;
+
+        $response = $this->graphqlClient->query($mutation);
+
+        if ($response->hasErrors()) {
+            return ['error' => $response->getErrors()];
+        } else {
+            // Returns an array with all the data returned by the GraphQL server.
+            return $response->getData();
+        }
+    }
+
+}

--- a/src/ClientTraits/OrganizationTrait.php
+++ b/src/ClientTraits/OrganizationTrait.php
@@ -9,7 +9,7 @@ trait OrganizationTrait {
     /**
      * @throws LagoonClientInitializeRequiredToInteractException
      */
-    public function removeUserFromOrganization(int $orgId, string $userEmail): array
+    public function removeUserFromOrganizationGroups(int $orgId, string $userEmail): array
     {
         if (empty($this->lagoonToken) || empty($this->graphqlClient)) {
             throw new LagoonClientInitializeRequiredToInteractException;


### PR DESCRIPTION
This pull request introduces a new method to the `GroupTrait` class, enhancing group management functionality by allowing users to be removed from groups via GraphQL. The change adds error handling to ensure proper client initialization before interaction.

Group management enhancements:

* Added the `removeUserFromGroup` method to `GroupTrait`, which removes a user from a specified group using a GraphQL mutation and handles errors if the client is not initialized.